### PR TITLE
Braver features

### DIFF
--- a/Breadcrumbs.py
+++ b/Breadcrumbs.py
@@ -272,7 +272,7 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
     template = '''
       <body id="inline-breadcrumbs">
         {stylesheet}
-        <div class="phantom">{breadcrumbs}<a href="{href}">Copy</a><a class="close" href="close">''' + chr(0x00D7) + '''</a></div>
+        <div class="phantom">{breadcrumbs}<a href="copy">Copy</a><a class="close" href="close">''' + chr(0x00D7) + '''</a></div>
       </body>
     '''
 
@@ -283,7 +283,6 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
     for region in self.view.sel():
       (row, col) = self.view.rowcol(region.begin())
 
-      id = str(row)
       crumb_elements = []
       breadcrumbs = make_breadcrumbs(self.view, row);
       for i, crumb in enumerate(breadcrumbs):
@@ -293,7 +292,6 @@ class BreadcrumbsPhantomCommand(sublime_plugin.TextCommand):
       breadcrumbs_string = separator.join(breadcrumbs)
       body = template.format(
           breadcrumbs=''.join(crumb_elements),
-          href=id,
           stylesheet=stylesheet
       )
       phantom = sublime.Phantom(


### PR DESCRIPTION
While reading your pr/3, I've realized that probably you have used the `self.strings` hashmap as a workaround, because it is not so obvious how to bind a current value of a variable to a closure. Here's how you can do that, and I think it's a cleaner approach than using a mutable state on the object.

I took a liberty of refactoring the way you use `navigate` function to close the phantoms, as in my opinion, it is better to have a function named simply `close` for that purpose than to using a fake navigation event.

I've also removed the call to `this.navigate('close')` in the `else` clause, as from what I see `self.phantom_set.update(phantoms)` simply replaces the old set of phantoms just fine. I guess you had this call in there simply to clear the strings array, but this is not required anymore.